### PR TITLE
Add a Jenkinsfile to be built by the Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(useAci: true, configurations: buildPlugin.recommendedConfigurations())


### PR DESCRIPTION
# Description
In order for TestCafe plugin to be built by the Jenkins CI Infrastructure and check pull requests, add a Jenkinsfile to the root of repository.